### PR TITLE
feat(resolveGameState): Additional features for game state resolver

### DIFF
--- a/src/__snapshots__/resolveGameState.test.js.snap
+++ b/src/__snapshots__/resolveGameState.test.js.snap
@@ -1,14 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`resolveGameState resolves an action that gives a tag 1`] = `
-Object {
-  "_partyRef": "party1",
-  "_uid": "player1",
-  "name": "Player",
-  "tags": Array [
-    "BORN ON EARTH",
-  ],
-}
+Array [
+  Object {
+    "_partyRef": "party1",
+    "_uid": "player1",
+    "name": "Player One",
+    "tags": Array [
+      "BORN ON EARTH",
+    ],
+  },
+  Object {
+    "_partyRef": "party1",
+    "_uid": "player2",
+    "name": "Player Two",
+    "tags": Array [],
+  },
+]
 `;
 
 exports[`resolveGameState resolves an action that gives a tag 2`] = `"starter-2"`;
@@ -19,7 +27,13 @@ Object {
     Object {
       "_partyRef": "party1",
       "_uid": "player1",
-      "name": "Player",
+      "name": "Player One",
+      "tags": Array [],
+    },
+    Object {
+      "_partyRef": "party1",
+      "_uid": "player2",
+      "name": "Player Two",
       "tags": Array [],
     },
   ],
@@ -94,7 +108,7 @@ The line at the employment office is long enough that you start daydreaming abou
   "player": Object {
     "_partyRef": "party1",
     "_uid": "player1",
-    "name": "Player",
+    "name": "Player One",
     "tags": Array [],
   },
 }

--- a/src/__snapshots__/resolveGameState.test.js.snap
+++ b/src/__snapshots__/resolveGameState.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`resolveGameState resolves an action that gives a tag 1`] = `
+exports[`resolveGameState resolves an action that gives a global tag as well 1`] = `
 Array [
   Object {
     "_partyRef": "party1",
@@ -8,6 +8,31 @@ Array [
     "name": "Player One",
     "tags": Array [
       "BORN ON EARTH",
+    ],
+  },
+  Object {
+    "_partyRef": "party1",
+    "_uid": "player2",
+    "name": "Player Two",
+    "tags": Array [],
+  },
+]
+`;
+
+exports[`resolveGameState resolves an action that gives a global tag as well 2`] = `
+Array [
+  "EARTH DESTROYED",
+]
+`;
+
+exports[`resolveGameState resolves an action that gives a tag 1`] = `
+Array [
+  Object {
+    "_partyRef": "party1",
+    "_uid": "player1",
+    "name": "Player One",
+    "tags": Array [
+      "RAISED BY DIVINE ORDER",
     ],
   },
   Object {
@@ -52,6 +77,10 @@ Object {
               Object {
                 "tag": "BORN ON EARTH",
                 "target": "SELF",
+              },
+              Object {
+                "tag": "EARTH DESTROYED",
+                "target": "GLOBAL",
               },
             ],
             "loseTags": Array [],

--- a/src/__snapshots__/resolveGameState.test.js.snap
+++ b/src/__snapshots__/resolveGameState.test.js.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`resolveGameState current node is calculated for the current player, not for all players 1`] = `"starter"`;
+
 exports[`resolveGameState resolves an action that gives a global tag as well 1`] = `
 Array [
   Object {

--- a/src/adventure.json
+++ b/src/adventure.json
@@ -17,6 +17,9 @@
 					"gainTags": [{
 						"target": "SELF",
 						"tag": "BORN ON EARTH"
+					}, {
+						"target": "GLOBAL",
+						"tag": "EARTH DESTROYED"
 					}],
 					"loseTags": []
 				}

--- a/src/resolveGameState.js
+++ b/src/resolveGameState.js
@@ -24,6 +24,10 @@ const resolveGameState = ({
 		// Iterate through all save steps
 		const saveStep: SaveStep = party.save[saveKey];
 		const node = adventure[saveStep._nodeRef];
+		const actingPlayer: ?Character = resolvedCharacters.find(_ => _._uid === saveStep._characterRef);
+		if (!actingPlayer) {
+			throw new Error('Player not found');
+		}
 		const allActions = node.options.reduce((acc, option) => [
 			...acc,
 			option.resultingAction,
@@ -36,7 +40,7 @@ const resolveGameState = ({
 		if (takenAction.effects) {
 			(takenAction.effects.gainTags || []).forEach((effect) => {
 				if (effect.target.toLowerCase() === 'self') {
-					player.tags.push(effect.tag);
+					actingPlayer.tags.push(effect.tag);
 				} else {
 					globalTags.push(effect.tag);
 				}
@@ -45,7 +49,7 @@ const resolveGameState = ({
 		if (takenAction.effects) {
 			(takenAction.effects.loseTags || []).forEach((effect) => {
 				if (effect.target.toLowerCase() === 'self') {
-					player.tags = player.tags.filter(_ => _ !== effect.tag);
+					actingPlayer.tags = actingPlayer.tags.filter(_ => _ !== effect.tag);
 				} else {
 					globalTags = globalTags.filter(_ => _ !== effect.tag);
 				}

--- a/src/resolveGameState.js
+++ b/src/resolveGameState.js
@@ -53,8 +53,10 @@ const resolveGameState = ({
 				}
 			});
 		}
-		// Set next node
-		currentNode = adventure[takenAction.targetNode];
+		// Set next node if the action was taken by the current player
+		if (actingPlayer === player) {
+			currentNode = adventure[takenAction.targetNode];
+		}
 	});
 	return {
 		globalTags,

--- a/src/resolveGameState.js
+++ b/src/resolveGameState.js
@@ -12,9 +12,7 @@ const resolveGameState = ({
 	playerId: string
 }): GameState => {
 	let globalTags: Array<Tag> = [];
-	const resolvedCharacters: Array<Character> = party.participants.map(c => ({
-		...c,
-	}));
+	const resolvedCharacters: Array<Character> = JSON.parse(JSON.stringify(party.participants));
 	let currentNode: Node = adventure.starter;
 	const player: ?Character = resolvedCharacters.find(_ => _._uid === playerId);
 	if (!player) {

--- a/src/resolveGameState.test.js
+++ b/src/resolveGameState.test.js
@@ -45,10 +45,22 @@ describe('resolveGameState', () => {
 			save1: {
 				_nodeRef: 'starter',
 				_characterRef: 'player1',
-				_actionID: '1',
+				_actionID: '2',
 			},
 		}));
 		expect(gameState.characters).toMatchSnapshot();
 		expect(gameState.currentNode.id).toMatchSnapshot();
+	});
+
+	it('resolves an action that gives a global tag as well', () => {
+		const gameState = resolveGameState(valueWithSave({
+			save1: {
+				_nodeRef: 'starter',
+				_characterRef: 'player1',
+				_actionID: '1',
+			},
+		}));
+		expect(gameState.characters).toMatchSnapshot();
+		expect(gameState.globalTags).toMatchSnapshot();
 	});
 });

--- a/src/resolveGameState.test.js
+++ b/src/resolveGameState.test.js
@@ -9,7 +9,12 @@ const defaultValue = {
 		save: {},
 		participants: [{
 			_uid: 'player1',
-			name: 'Player',
+			name: 'Player One',
+			tags: [],
+			_partyRef: 'party1',
+		}, {
+			_uid: 'player2',
+			name: 'Player Two',
 			tags: [],
 			_partyRef: 'party1',
 		}],
@@ -43,7 +48,7 @@ describe('resolveGameState', () => {
 				_actionID: '1',
 			},
 		}));
-		expect(gameState.player).toMatchSnapshot();
+		expect(gameState.characters).toMatchSnapshot();
 		expect(gameState.currentNode.id).toMatchSnapshot();
 	});
 });

--- a/src/resolveGameState.test.js
+++ b/src/resolveGameState.test.js
@@ -63,4 +63,15 @@ describe('resolveGameState', () => {
 		expect(gameState.characters).toMatchSnapshot();
 		expect(gameState.globalTags).toMatchSnapshot();
 	});
+
+	it('current node is calculated for the current player, not for all players', () => {
+		const gameState = resolveGameState(valueWithSave({
+			save1: {
+				_nodeRef: 'starter',
+				_characterRef: 'player2',
+				_actionID: '1',
+			},
+		}));
+		expect(gameState.currentNode.id).toMatchSnapshot();
+	});
 });


### PR DESCRIPTION
- When an effect has `target: 'SELF'`, that affects the chosing player, not the current player
- Added test for giving global tags
- Correctly calculate the current node for the current player